### PR TITLE
feat: 在历史记录管理中添加显示权重信息的开关

### DIFF
--- a/app/view/settings/history/history_management.py
+++ b/app/view/settings/history/history_management.py
@@ -67,6 +67,29 @@ class roll_call_history(GroupHeaderCardWidget):
             )
         )
 
+        # 是否显示权重
+        self.select_weight_switch = SwitchButton()
+        self.select_weight_switch.setOffText(
+            get_content_switchbutton_name_async(
+                "history_management", "select_weight", "disable"
+            )
+        )
+        self.select_weight_switch.setOnText(
+            get_content_switchbutton_name_async(
+                "history_management", "select_weight", "enable"
+            )
+        )
+        self.select_weight_switch.setChecked(
+            readme_settings_async("history_management", "select_weight")
+        )
+        self.select_weight_switch.checkedChanged.connect(
+            lambda: update_settings(
+                "history_management",
+                "select_weight",
+                self.select_weight_switch.isChecked(),
+            )
+        )
+
         # 选择班级下拉框
         self.class_name_combo = ComboBox()
         self.refresh_class_list()  # 初始化班级列表
@@ -111,6 +134,14 @@ class roll_call_history(GroupHeaderCardWidget):
                 "history_management", "show_roll_call_history"
             ),
             self.show_roll_call_history_button_switch,
+        )
+        self.addGroup(
+            get_theme_icon("ic_fluent_data_histogram_20_filled"),
+            get_content_name_async("history_management", "select_weight"),
+            get_content_description_async(
+                "history_management", "select_weight"
+            ),
+            self.select_weight_switch,
         )
         self.addGroup(
             get_theme_icon("ic_fluent_class_20_filled"),


### PR DESCRIPTION
# feat: 在历史记录管理中添加显示权重信息的开关

## 📝 更改说明

本 PR 实现了在历史记录管理页面中控制“显示权重信息”的功能，修复了用户无法开启该选项的问题。

### ✨ 新增功能
- 在 `app/view/settings/history/history_management.py` 的 `roll_call_history` 类中添加了 `SwitchButton` 组件。
- 实现了该开关与 `select_weight` 设置项的绑定，支持开启/关闭权重显示。
- 通过 `update_settings` 实现了设置的实时保存。

### 🐛 修复问题
- 关联 Issue: #71 ([BUG] 历史记录应该显示权重信息)

## ⚠️ 声明 (Disclaimer)

**注意**：本代码由 **Jules** 编写，仅经过了粗略的审查，**仅供参考**，不应被直接合并！请在合并前仔细审查逻辑和实现细节，以确保符合项目标准。
>

## ✅ 检查清单
- [x] PR 标题简洁明了，使用了约定式提交规范 (feat/fix等)
- [x] 提供了详细的更改说明
- [x] 已关联相关的 Issue
- [x] 代码修改旨在解决特定问题，且经过初步验证