### PR TITLE
`fix(roll_call): 清除缓存以确保下次抽取读取最新记录`

### DIFF
--- a/app/common/roll_call/roll_call_utils.py
+++ b/app/common/roll_call/roll_call_utils.py
@@ -504,6 +504,11 @@ class RollCallUtils:
             group_filter: 小组过滤器
         """
         reset_drawn_record(window, class_name, gender_filter, group_filter)
+        
+        # 清除缓存，确保下次抽取时重新读取记录
+        record_key = f"{class_name}_{gender_filter}_{group_filter}"
+        if record_key in RollCallUtils._drawn_record_cache:
+            del RollCallUtils._drawn_record_cache[record_key]
 
     @staticmethod
     def update_start_button_state(button, total_count):
@@ -637,6 +642,11 @@ class RollCallUtils:
                 group=group_filter,
                 student_name=selected_students,
             )
+            
+            # 清除缓存，确保下次抽取时重新读取最新的已抽取记录
+            record_key = f"{class_name}_{gender_filter}_{group_filter}"
+            if record_key in RollCallUtils._drawn_record_cache:
+                del RollCallUtils._drawn_record_cache[record_key]
 
         if selected_students_dict:
             save_roll_call_history(


### PR DESCRIPTION
之所以提交pr是因为你说不负责的地方不能随便改(顺手修bug）：（（（（（（
This pull request improves the reliability of student selection in the roll call utility by ensuring that the internal cache of drawn records is cleared whenever records are reset or updated. This guarantees that subsequent draws always use the most up-to-date data.

Cache management improvements:

* In `reset_drawn_records`, after resetting the record, the method now deletes the corresponding entry from `RollCallUtils._drawn_record_cache` to ensure fresh data is used for future draws.
* In `record_drawn_students`, after recording selected students, the method also deletes the relevant cache entry to maintain consistency with the latest drawn records.