### PR TITLE
更改获取ip接口，防止ipv6地址报错

### DIFF
--- a/app/tools/online_status.py
+++ b/app/tools/online_status.py
@@ -68,17 +68,14 @@ def _get_local_ip() -> str:
 
 def _get_public_ip(timeout_seconds: float = 5.0) -> Optional[str]:
     services = [
-        "https://uapis.cn/api/v1/network/myip",
+        "https://321260.xyz/api/ip.php", # v4出口网络
     ]
 
     for service in services:
         try:
             response = requests.get(service, timeout=timeout_seconds)
             if response.status_code == 200:
-                data = response.json()
-                ip = data.get("ip")
-                if ip:
-                    return ip
+                return response.text.strip()
         except Exception:
             continue
 


### PR DESCRIPTION
我发现原代码中提供的接口会识别ipv6地址，导致在线状态无法上报
这里我修改了一下，这个是我自建的获取接口，建议你们可以多添加一些获取接口
<img width="292" height="223" alt="image" src="https://github.com/user-attachments/assets/953f876e-c1c7-4b07-98de-cf7e0bdb3725" />
