### PR TITLE
fix(i18n): 计时器"透明度"改为"不透明度"

### DIFF
--- a/app/Language/modules/countdown_timer.py
+++ b/app/Language/modules/countdown_timer.py
@@ -27,7 +27,7 @@ countdown_timer = {
             "description": "退出全屏",
             "pushbutton_name": "退出全屏",
         },
-        "opacity": {"name": "透明度", "description": "调整窗口透明度"},
+        "opacity": {"name": "不透明度", "description": "调整窗口不透明度"},
         "presets": {"name": "预设", "description": "常用倒计时预设"},
         "preset_common": {"name": "常用", "description": "常用预设"},
         "preset_recent": {"name": "最近", "description": "最近使用"},


### PR DESCRIPTION
## 修改内容

修复 #234

计时器右上角的 opacity 控制实际为不透明度（值越大越不透明），中文翻译"透明度"与实际含义相反。

### 修改
- `app/Language/modules/countdown_timer.py`：中文 ZH_CN 的 opacity 字段，name 从"透明度"改为"不透明度"，description 从"调整窗口透明度"改为"调整窗口不透明度"

### 说明
- 日语 JA_JP 翻译已正确使用"不透明度"，本次修改使中文翻译与之一致
- 英文 EN_US 使用"Opacity"本身即"不透明度"之意，无需修改