### PR TITLE
feat: 添加名单表格搜索筛选功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,6 +184,7 @@ cython_debug/
 
 # VSCode
 .vscode/settings.json
+.vscode/launch.json
 /.trae
 /app/config
 /app/config

--- a/app/Language/modules/history.py
+++ b/app/Language/modules/history.py
@@ -234,6 +234,10 @@ roll_call_history_table = {
             "name": "导出",
             "description": "导出按钮文本",
         },
+        "export_default_filename": {
+            "name": "点名记录",
+            "description": "导出文件默认文件名中的描述文字",
+        },
     },
     "EN_US": {
         "title": {
@@ -335,6 +339,10 @@ roll_call_history_table = {
         "export_button": {
             "name": "Export",
             "description": "Export button text",
+        },
+        "export_default_filename": {
+            "name": "Picking records",
+            "description": "Description text in the default export filename",
         },
         "select_weight": {
             "name": "Show weight",
@@ -443,6 +451,10 @@ roll_call_history_table = {
             "name": "エクスポート",
             "description": "エクスポートボタンテキスト",
         },
+        "export_default_filename": {
+            "name": "点呼記録",
+            "description": "エクスポートファイルのデフォルトファイル名の説明文",
+        },
         "select_weight": {
             "name": "重みを表示",
             "description": "テーブルに重みを表示するかどうか",
@@ -491,6 +503,10 @@ lottery_history_table = {
         "export_button": {
             "name": "导出",
             "description": "导出按钮文本",
+        },
+        "export_default_filename": {
+            "name": "抽奖记录",
+            "description": "导出文件默认文件名中的描述文字",
         },
     },
     "EN_US": {
@@ -548,6 +564,10 @@ lottery_history_table = {
             "name": "Export",
             "description": "Export button text",
         },
+        "export_default_filename": {
+            "name": "Lottery records",
+            "description": "Description text in the default export filename",
+        },
     },
     "JA_JP": {
         "title": {
@@ -603,6 +623,10 @@ lottery_history_table = {
         "export_button": {
             "name": "エクスポート",
             "description": "エクスポートボタンテキスト",
+        },
+        "export_default_filename": {
+            "name": "抽選記録",
+            "description": "エクスポートファイルのデフォルトファイル名の説明文",
         },
     },
 }

--- a/app/Language/modules/history.py
+++ b/app/Language/modules/history.py
@@ -226,6 +226,14 @@ roll_call_history_table = {
             "name": "公平抽取",
             "description": "公平抽取模式",
         },
+        "export": {
+            "name": "导出记录",
+            "description": "将当前表格数据导出为文件",
+        },
+        "export_button": {
+            "name": "导出",
+            "description": "导出按钮文本",
+        },
     },
     "EN_US": {
         "title": {
@@ -319,6 +327,14 @@ roll_call_history_table = {
         "draw_method_weight": {
             "name": "Fair pick",
             "description": "Fair picking mode",
+        },
+        "export": {
+            "name": "Export records",
+            "description": "Export current table data to a file",
+        },
+        "export_button": {
+            "name": "Export",
+            "description": "Export button text",
         },
         "select_weight": {
             "name": "Show weight",
@@ -419,6 +435,14 @@ roll_call_history_table = {
             "name": "公平抽出",
             "description": "公平抽出モード",
         },
+        "export": {
+            "name": "記録をエクスポート",
+            "description": "現在のテーブルデータをファイルにエクスポート",
+        },
+        "export_button": {
+            "name": "エクスポート",
+            "description": "エクスポートボタンテキスト",
+        },
         "select_weight": {
             "name": "重みを表示",
             "description": "テーブルに重みを表示するかどうか",
@@ -459,6 +483,14 @@ lottery_history_table = {
         "HeaderLabels_Individual_weight": {
             "name": ["抽奖时间", "抽取数量", "课程", "权重"],
             "description": "抽奖历史记录表格列标题（单次记录）",
+        },
+        "export": {
+            "name": "导出记录",
+            "description": "将当前表格数据导出为文件",
+        },
+        "export_button": {
+            "name": "导出",
+            "description": "导出按钮文本",
         },
     },
     "EN_US": {
@@ -508,6 +540,14 @@ lottery_history_table = {
             },
             "description": "Lottery history table title column header weight (individual)",
         },
+        "export": {
+            "name": "Export records",
+            "description": "Export current table data to a file",
+        },
+        "export_button": {
+            "name": "Export",
+            "description": "Export button text",
+        },
     },
     "JA_JP": {
         "title": {
@@ -555,6 +595,14 @@ lottery_history_table = {
                 "3": "重み",
             },
             "description": "抽選履歴テーブルの列タイトル（単一記録）",
+        },
+        "export": {
+            "name": "記録をエクスポート",
+            "description": "現在のテーブルデータをファイルにエクスポート",
+        },
+        "export_button": {
+            "name": "エクスポート",
+            "description": "エクスポートボタンテキスト",
         },
     },
 }

--- a/app/Language/modules/list_management.py
+++ b/app/Language/modules/list_management.py
@@ -122,6 +122,14 @@ roll_call_table = {
             "name": "选择班级",
             "description": "选择要显示的点名班级",
         },
+        "search": {
+            "name": "搜索名单",
+            "description": "在名单中搜索学生",
+        },
+        "search_placeholder": {
+            "name": "输入学号、姓名、性别、小组或标签进行筛选",
+            "description": "搜索框占位符",
+        },
         "HeaderLabels": {
             "name": ["存在", "学号", "姓名", "性别", "小组", "标签"],
             "description": "点名表格的列标题",
@@ -150,6 +158,14 @@ roll_call_table = {
         "select_class_name": {
             "name": "Select class",
             "description": "Select the class to show",
+        },
+        "search": {
+            "name": "Search list",
+            "description": "Search students in the list",
+        },
+        "search_placeholder": {
+            "name": "Filter by ID, name, gender, group or tags",
+            "description": "Search box placeholder",
         },
         "HeaderLabels": {
             "name": {
@@ -189,6 +205,14 @@ roll_call_table = {
         "select_class_name": {
             "name": "クラスを選択",
             "description": "表示する点呼クラスを選択",
+        },
+        "search": {
+            "name": "リスト検索",
+            "description": "リスト内の学生を検索",
+        },
+        "search_placeholder": {
+            "name": "学籍番号、氏名、性別、グループ、タグで絞り込み",
+            "description": "検索ボックスのプレースホルダー",
         },
         "HeaderLabels": {
             "name": ["存在", "学籍番号", "氏名", "性別", "グループ", "タグ"],
@@ -311,6 +335,14 @@ lottery_table = {
             "name": "选择奖池",
             "description": "选择要显示的抽奖奖池",
         },
+        "search": {
+            "name": "搜索名单",
+            "description": "在名单中搜索奖品",
+        },
+        "search_placeholder": {
+            "name": "输入序号、奖品、权重、标签或数量进行筛选",
+            "description": "搜索框占位符",
+        },
         "HeaderLabels": {
             "name": ["存在", "序号", "奖品", "权重", "标签", "数量"],
             "description": "抽奖表格的列标题",
@@ -339,6 +371,14 @@ lottery_table = {
         "select_pool_name": {
             "name": "Select pool",
             "description": "Select the pool to show",
+        },
+        "search": {
+            "name": "Search list",
+            "description": "Search prizes in the list",
+        },
+        "search_placeholder": {
+            "name": "Filter by serial, prize, weight, tags or count",
+            "description": "Search box placeholder",
         },
         "HeaderLabels": {
             "name": {
@@ -378,6 +418,14 @@ lottery_table = {
         "select_pool_name": {
             "name": "賞プールを選択",
             "description": "表示する抽選賞プールを選択",
+        },
+        "search": {
+            "name": "リスト検索",
+            "description": "リスト内の賞品を検索",
+        },
+        "search_placeholder": {
+            "name": "番号、賞品、重み、タグ、数量で絞り込み",
+            "description": "検索ボックスのプレースホルダー",
         },
         "HeaderLabels": {
             "name": ["存在", "番号", "賞品", "重み", "タグ", "数量"],

--- a/app/Language/modules/list_management.py
+++ b/app/Language/modules/list_management.py
@@ -797,7 +797,17 @@ qfiledialog = {
                     "name": "Excel 文件 (*.xlsx);;CSV 文件 (*.csv);;TXT 文件（仅姓名） (*.txt)",
                     "description": "保存学生名单对话框过滤器",
                 },
-            }
+            },
+            "export_history": {
+                "caption": {
+                    "name": "导出点名记录",
+                    "description": "导出点名记录对话框标题",
+                },
+                "filter": {
+                    "name": "Excel 文件 (*.xlsx);;CSV 文件 (*.csv);;TXT 文件 (*.txt)",
+                    "description": "导出点名记录对话框过滤器",
+                },
+            },
         },
         "lottery": {
             "export_prize_name": {
@@ -809,7 +819,17 @@ qfiledialog = {
                     "name": "Excel 文件 (*.xlsx);;CSV 文件 (*.csv);;TXT 文件（仅奖品名） (*.txt)",
                     "description": "保存奖品名单对话框过滤器",
                 },
-            }
+            },
+            "export_history": {
+                "caption": {
+                    "name": "导出抽奖记录",
+                    "description": "导出抽奖记录对话框标题",
+                },
+                "filter": {
+                    "name": "Excel 文件 (*.xlsx);;CSV 文件 (*.csv);;TXT 文件 (*.txt)",
+                    "description": "导出抽奖记录对话框过滤器",
+                },
+            },
         },
     },
     "EN_US": {
@@ -823,7 +843,17 @@ qfiledialog = {
                     "name": "Excel files (*.xlsx);;CSV files (*.csv);;TXT files (name only) (*.txt)",
                     "description": "Save student list dialog filter",
                 },
-            }
+            },
+            "export_history": {
+                "caption": {
+                    "name": "Export picking records",
+                    "description": "Export picking records dialog title",
+                },
+                "filter": {
+                    "name": "Excel files (*.xlsx);;CSV files (*.csv);;TXT files (*.txt)",
+                    "description": "Export picking records dialog filter",
+                },
+            },
         },
         "lottery": {
             "export_prize_name": {
@@ -835,7 +865,17 @@ qfiledialog = {
                     "name": "Excel files (*.xlsx);;CSV files (*.csv);;TXT files (only prizes) (*.txt)",
                     "description": "Save prize list dialog filter",
                 },
-            }
+            },
+            "export_history": {
+                "caption": {
+                    "name": "Export lottery records",
+                    "description": "Export lottery records dialog title",
+                },
+                "filter": {
+                    "name": "Excel files (*.xlsx);;CSV files (*.csv);;TXT files (*.txt)",
+                    "description": "Export lottery records dialog filter",
+                },
+            },
         },
     },
     "JA_JP": {
@@ -849,7 +889,17 @@ qfiledialog = {
                     "name": "Excelファイル (*.xlsx);;CSVファイル (*.csv);;TXTファイル（氏名のみ） (*.txt)",
                     "description": "学生リスト保存ダイアログフィルター",
                 },
-            }
+            },
+            "export_history": {
+                "caption": {
+                    "name": "点呼記録をエクスポート",
+                    "description": "点呼記録エクスポートダイアログタイトル",
+                },
+                "filter": {
+                    "name": "Excelファイル (*.xlsx);;CSVファイル (*.csv);;TXTファイル (*.txt)",
+                    "description": "点呼記録エクスポートダイアログフィルター",
+                },
+            },
         },
         "lottery": {
             "export_prize_name": {
@@ -861,7 +911,17 @@ qfiledialog = {
                     "name": "Excelファイル (*.xlsx);;CSVファイル (*.csv);;TXTファイル（賞品名のみ） (*.txt)",
                     "description": "賞品リスト保存ダイアログフィルター",
                 },
-            }
+            },
+            "export_history": {
+                "caption": {
+                    "name": "抽選記録をエクスポート",
+                    "description": "抽選記録エクスポートダイアログタイトル",
+                },
+                "filter": {
+                    "name": "Excelファイル (*.xlsx);;CSVファイル (*.csv);;TXTファイル (*.txt)",
+                    "description": "抽選記録エクスポートダイアログフィルター",
+                },
+            },
         },
     },
 }

--- a/app/Language/modules/list_management.py
+++ b/app/Language/modules/list_management.py
@@ -782,6 +782,184 @@ notification = {
             },
         },
     },
+    "JA_JP": {
+        "roll_call": {
+            "class_name_setting": {
+                "title": {
+                    "name": "クラス名設定",
+                    "description": "クラス名設定通知タイトル",
+                },
+                "content": {
+                    "name": "クラス名設定ウィンドウを開きました",
+                    "description": "クラス名設定通知内容",
+                },
+            },
+            "import_student_name": {
+                "title": {
+                    "name": "学生リストインポート",
+                    "description": "学生リストインポート通知タイトル",
+                },
+                "content": {
+                    "name": "学生リストインポートウィンドウを開きました",
+                    "description": "学生リストインポート通知内容",
+                },
+            },
+            "name_setting": {
+                "title": {
+                    "name": "氏名設定",
+                    "description": "氏名設定通知タイトル",
+                },
+                "content": {
+                    "name": "氏名設定ウィンドウを開きました",
+                    "description": "氏名設定通知内容",
+                },
+            },
+            "gender_setting": {
+                "title": {
+                    "name": "性別設定",
+                    "description": "性別設定通知タイトル",
+                },
+                "content": {
+                    "name": "性別設定ウィンドウを開きました",
+                    "description": "性別設定通知内容",
+                },
+            },
+            "group_setting": {
+                "title": {
+                    "name": "グループ設定",
+                    "description": "グループ設定通知タイトル",
+                },
+                "content": {
+                    "name": "グループ設定ウィンドウを開きました",
+                    "description": "グループ設定通知内容",
+                },
+            },
+            "tag_setting": {
+                "title": {
+                    "name": "タグ設定",
+                    "description": "タグ設定通知タイトル",
+                },
+                "content": {
+                    "name": "タグ設定ウィンドウを開きました",
+                    "description": "タグ設定通知内容",
+                },
+            },
+            "export": {
+                "title": {
+                    "success": {
+                        "name": "エクスポート成功",
+                        "description": "エクスポート成功通知タイトル",
+                    },
+                    "failure": {
+                        "name": "エクスポート失敗",
+                        "description": "エクスポート失敗通知タイトル",
+                    },
+                },
+                "content": {
+                    "success": {
+                        "name": "学生リストをエクスポートしました: {path}",
+                        "description": "エクスポート成功通知内容",
+                    },
+                    "failure": {
+                        "name": "エクスポートするクラスを先に選択してください",
+                        "description": "エクスポート失敗通知内容（クラス未選択）",
+                    },
+                    "error": {
+                        "name": "{message}",
+                        "description": "エクスポートエラー通知内容",
+                    },
+                },
+            },
+        },
+        "lottery": {
+            "pool_name_setting": {
+                "title": {
+                    "name": "賞プール名設定",
+                    "description": "賞プール名設定通知タイトル",
+                },
+                "content": {
+                    "name": "賞プール名設定ウィンドウを開きました",
+                    "description": "賞プール名設定通知内容",
+                },
+            },
+            "import_prize_name": {
+                "title": {
+                    "name": "賞品リストインポート",
+                    "description": "賞品リストインポート通知タイトル",
+                },
+                "content": {
+                    "name": "賞品リストインポートウィンドウを開きました",
+                    "description": "賞品リストインポート通知内容",
+                },
+            },
+            "prize_setting": {
+                "title": {
+                    "name": "賞品設定",
+                    "description": "賞品設定通知タイトル",
+                },
+                "content": {
+                    "name": "賞品設定ウィンドウを開きました",
+                    "description": "賞品設定通知内容",
+                },
+            },
+            "prize_weight_setting": {
+                "title": {
+                    "name": "賞品重み設定",
+                    "description": "賞品重み設定通知タイトル",
+                },
+                "content": {
+                    "name": "賞品重み設定ウィンドウを開きました",
+                    "description": "賞品重み設定通知内容",
+                },
+            },
+            "tag_setting": {
+                "title": {
+                    "name": "タグ設定",
+                    "description": "タグ設定通知タイトル",
+                },
+                "content": {
+                    "name": "タグ設定ウィンドウを開きました",
+                    "description": "タグ設定通知内容",
+                },
+            },
+            "prize_count_setting": {
+                "title": {
+                    "name": "賞品数量設定",
+                    "description": "賞品数量設定通知タイトル",
+                },
+                "content": {
+                    "name": "賞品数量設定ウィンドウを開きました",
+                    "description": "賞品数量設定通知内容",
+                },
+            },
+            "export": {
+                "title": {
+                    "success": {
+                        "name": "エクスポート成功",
+                        "description": "エクスポート成功通知タイトル",
+                    },
+                    "failure": {
+                        "name": "エクスポート失敗",
+                        "description": "エクスポート失敗通知タイトル",
+                    },
+                },
+                "content": {
+                    "success": {
+                        "name": "賞品リストをエクスポートしました: {path}",
+                        "description": "エクスポート成功通知内容",
+                    },
+                    "failure": {
+                        "name": "エクスポートする賞プールを先に選択してください",
+                        "description": "エクスポート失敗通知内容（賞プール未選択）",
+                    },
+                    "error": {
+                        "name": "{message}",
+                        "description": "エクスポートエラー通知内容",
+                    },
+                },
+            },
+        },
+    },
 }
 
 # QFileDialog 文本配置

--- a/app/view/settings/history/export_utils.py
+++ b/app/view/settings/history/export_utils.py
@@ -321,7 +321,7 @@ def export_history_table_data(
         get_any_position_value_async(
             "qfiledialog", i18n_domain, "export_history", "caption", "name"
         ),
-        f"{current_name}_{get_content_name_async(f'{i18n_domain}_history_table', 'export_default_filename')}-SecRandom",
+        f"{current_name}_{get_content_name_async(f'{i18n_domain}_history_table', 'export_default_filename') or ''}-SecRandom",
         get_any_position_value_async(
             "qfiledialog", i18n_domain, "export_history", "filter", "name"
         ),

--- a/app/view/settings/history/export_utils.py
+++ b/app/view/settings/history/export_utils.py
@@ -377,7 +377,7 @@ def export_history_table_data(
         config = NotificationConfig(
             title=get_any_position_value_async(
                 "notification", i18n_domain, "export", "title", "success", "name"
-            ),
+            ) or "",
             content=(
                 get_any_position_value_async(
                     "notification", i18n_domain, "export", "content", "success", "name"
@@ -394,7 +394,7 @@ def export_history_table_data(
         config = NotificationConfig(
             title=get_any_position_value_async(
                 "notification", i18n_domain, "export", "title", "failure", "name"
-            ),
+            ) or "",
             content=(
                 get_any_position_value_async(
                     "notification", i18n_domain, "export", "content", "error", "name"

--- a/app/view/settings/history/export_utils.py
+++ b/app/view/settings/history/export_utils.py
@@ -1,0 +1,128 @@
+from loguru import logger
+from PySide6.QtWidgets import QFileDialog
+
+from app.tools.config import NotificationConfig, NotificationType, show_notification
+from app.tools.path_utils import get_path
+from app.Language.obtain_language import (
+    get_any_position_value_async,
+    get_content_name_async,
+)
+
+
+def _get_name_column_index(current_mode: int):
+    if current_mode == 0:
+        return 1
+    elif current_mode == 1:
+        return 2
+    return None
+
+
+def export_history_table_data(
+    table_widget,
+    current_mode: int,
+    i18n_domain: str,
+    current_name: str,
+    parent_widget=None,
+):
+    if table_widget.rowCount() == 0:
+        return
+
+    file_path, selected_filter = QFileDialog.getSaveFileName(
+        parent_widget,
+        get_any_position_value_async(
+            "qfiledialog", i18n_domain, "export_history", "caption", "name"
+        ),
+        f"{current_name}_{get_content_name_async(f'{i18n_domain}_history_table', 'export_default_filename')}-SecRandom",
+        get_any_position_value_async(
+            "qfiledialog", i18n_domain, "export_history", "filter", "name"
+        ),
+    )
+
+    if not file_path:
+        return
+
+    export_type = (
+        "excel"
+        if ".xlsx" in selected_filter
+        else "csv"
+        if ".csv" in selected_filter
+        else "txt"
+    )
+
+    if export_type == "excel" and not file_path.endswith(".xlsx"):
+        file_path += ".xlsx"
+    elif export_type == "csv" and not file_path.endswith(".csv"):
+        file_path += ".csv"
+    elif export_type == "txt" and not file_path.endswith(".txt"):
+        file_path += ".txt"
+
+    try:
+        target_path = get_path(file_path)
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+
+        headers = []
+        for col in range(table_widget.columnCount()):
+            header_item = table_widget.horizontalHeaderItem(col)
+            headers.append(header_item.text() if header_item else f"列{col}")
+
+        export_data = []
+        for row in range(table_widget.rowCount()):
+            row_data = {}
+            for col in range(table_widget.columnCount()):
+                item = table_widget.item(row, col)
+                row_data[headers[col]] = item.text() if item else ""
+            export_data.append(row_data)
+
+        if export_type == "excel":
+            import pandas as pd
+
+            df = pd.DataFrame(export_data)
+            df.to_excel(str(target_path), index=False, engine="openpyxl")
+        elif export_type == "csv":
+            import pandas as pd
+
+            df = pd.DataFrame(export_data)
+            df.to_csv(str(target_path), index=False, encoding="utf-8-sig")
+        else:
+            name_col_idx = _get_name_column_index(current_mode)
+            with open(str(target_path), "w", encoding="utf-8") as f:
+                for row in range(table_widget.rowCount()):
+                    if name_col_idx is not None:
+                        item = table_widget.item(row, name_col_idx)
+                        f.write(f"{item.text()}\n" if item else "\n")
+                    else:
+                        for col in range(table_widget.columnCount()):
+                            item = table_widget.item(row, col)
+                            f.write(f"{item.text()}\t" if item else "\t")
+                        f.write("\n")
+
+        config = NotificationConfig(
+            title=get_any_position_value_async(
+                "notification", i18n_domain, "export", "title", "success", "name"
+            ),
+            content=(
+                get_any_position_value_async(
+                    "notification", i18n_domain, "export", "content", "success", "name"
+                )
+                or ""
+            ).format(path=file_path),
+            duration=3000,
+        )
+        show_notification(NotificationType.SUCCESS, config, parent=parent_widget)
+        logger.info(f"历史记录导出成功: {file_path}")
+
+    except Exception as e:
+        logger.error(f"导出历史记录失败: {e}")
+        config = NotificationConfig(
+            title=get_any_position_value_async(
+                "notification", i18n_domain, "export", "title", "failure", "name"
+            ),
+            content=(
+                get_any_position_value_async(
+                    "notification", i18n_domain, "export", "content", "error", "name"
+                )
+                or ""
+            ).format(message=str(e)),
+            duration=3000,
+        )
+        show_notification(NotificationType.ERROR, config, parent=parent_widget)

--- a/app/view/settings/history/export_utils.py
+++ b/app/view/settings/history/export_utils.py
@@ -1,3 +1,5 @@
+import csv
+
 from loguru import logger
 from PySide6.QtWidgets import QFileDialog
 
@@ -6,6 +8,24 @@ from app.tools.path_utils import get_path
 from app.Language.obtain_language import (
     get_any_position_value_async,
     get_content_name_async,
+)
+from app.common.history.history_reader import (
+    get_roll_call_student_list,
+    get_roll_call_history_data,
+    filter_roll_call_history_by_subject,
+    get_roll_call_students_data,
+    get_roll_call_session_data,
+    get_roll_call_student_stats_data,
+    check_class_has_gender_or_group,
+    get_lottery_pool_list,
+    get_lottery_history_data,
+    get_lottery_prizes_data,
+    get_lottery_session_data,
+    get_lottery_prize_stats_data,
+)
+from app.common.history.weight_utils import (
+    calculate_weight,
+    format_weight_for_display,
 )
 
 
@@ -17,16 +37,285 @@ def _get_name_column_index(current_mode: int):
     return None
 
 
+def _build_roll_call_export_data(
+    current_name: str,
+    current_mode: int,
+    current_subject: str,
+    current_student_name: str,
+):
+    headers = []
+    rows = []
+
+    cleaned_students = get_roll_call_student_list(current_name)
+    history_data = get_roll_call_history_data(current_name)
+
+    if current_subject:
+        history_data = filter_roll_call_history_by_subject(
+            history_data, current_subject
+        )
+
+    has_gender, has_group = check_class_has_gender_or_group(current_name)
+    has_class_record = False
+
+    if current_mode == 0:
+        students_data = get_roll_call_students_data(
+            cleaned_students, history_data, current_subject
+        )
+        students_weight_data = calculate_weight(
+            students_data, current_name, current_subject
+        )
+        format_weight, _, _ = format_weight_for_display(
+            students_weight_data, "next_weight"
+        )
+
+        headers = ["ID", "Name"]
+        if has_gender:
+            headers.append("Gender")
+        if has_group:
+            headers.append("Group")
+        headers.append("Count")
+        headers.append("Weight")
+
+        for i, student in enumerate(students_data):
+            row = [
+                student.get("id", ""),
+                student.get("name", ""),
+            ]
+            if has_gender:
+                row.append(student.get("gender", ""))
+            if has_group:
+                row.append(student.get("group", ""))
+            row.append(
+                str(student.get("total_count_str", student.get("total_count", 0)))
+            )
+            if i < len(students_weight_data):
+                row.append(
+                    str(format_weight(students_weight_data[i].get("next_weight", "")))
+                )
+            else:
+                row.append("")
+            rows.append(row)
+
+    elif current_mode == 1:
+        students_data = get_roll_call_session_data(
+            cleaned_students, history_data, current_subject
+        )
+        has_class_record = any(
+            student.get("class_name", "") for student in students_data
+        )
+        format_weight, _, _ = format_weight_for_display(students_data, "weight")
+
+        students_data.sort(key=lambda x: x.get("draw_time", ""), reverse=True)
+
+        headers = ["Time", "ID", "Name"]
+        if has_gender:
+            headers.append("Gender")
+        if has_group:
+            headers.append("Group")
+        if has_class_record:
+            headers.append("Subject")
+        headers.append("Weight")
+
+        for student in students_data:
+            row = [
+                student.get("draw_time", ""),
+                student.get("id", ""),
+                student.get("name", ""),
+            ]
+            if has_gender:
+                gender = student.get("gender", "")
+                row.append(str(gender) if gender else "")
+            if has_group:
+                group = student.get("group", "")
+                row.append(str(group) if group else "")
+            if has_class_record:
+                class_name = student.get("class_name", "")
+                row.append(str(class_name) if class_name else "")
+            row.append(str(format_weight(student.get("weight", ""))))
+            rows.append(row)
+
+    else:
+        students_data = get_roll_call_student_stats_data(
+            cleaned_students, history_data, current_student_name, current_subject
+        )
+        has_class_record = any(
+            student.get("class_name", "") for student in students_data
+        )
+        format_weight, _, _ = format_weight_for_display(students_data, "weight")
+
+        students_data.sort(key=lambda x: x.get("draw_time", ""), reverse=True)
+
+        headers = ["Time", "Method", "Count"]
+        if has_gender:
+            headers.append("Gender")
+        if has_group:
+            headers.append("Group")
+        if has_class_record:
+            headers.append("Subject")
+        headers.append("Weight")
+
+        for student in students_data:
+            row = [
+                student.get("draw_time", ""),
+                str(student.get("draw_method", "")),
+                str(student.get("draw_people_numbers", 0)),
+            ]
+            if has_gender:
+                draw_gender = student.get("draw_gender", "")
+                row.append(draw_gender if draw_gender else "")
+            if has_group:
+                draw_group = student.get("draw_group", "")
+                row.append(draw_group if draw_group else "")
+            if has_class_record:
+                class_name = student.get("class_name", "")
+                row.append(str(class_name) if class_name else "")
+            row.append(str(format_weight(student.get("weight", ""))))
+            rows.append(row)
+
+    return headers, rows
+
+
+def _build_lottery_export_data(
+    current_name: str,
+    current_mode: int,
+    current_subject: str,
+    current_lottery_name: str,
+):
+    headers = []
+    rows = []
+
+    cleaned_lotterys = get_lottery_pool_list(current_name)
+    history_data = get_lottery_history_data(current_name)
+
+    has_class_record = False
+
+    if current_mode == 0:
+        lotterys_data = get_lottery_prizes_data(cleaned_lotterys, history_data)
+        format_weight, _, _ = format_weight_for_display(lotterys_data, "weight")
+
+        headers = ["ID", "Name", "Count", "Weight"]
+
+        for lottery in lotterys_data:
+            row = [
+                lottery.get("id", ""),
+                lottery.get("name", ""),
+                str(lottery.get("total_count_str", lottery.get("total_count", 0))),
+                str(format_weight(lottery.get("weight", 0))),
+            ]
+            rows.append(row)
+
+    elif current_mode == 1:
+        lotterys_data = get_lottery_session_data(
+            cleaned_lotterys, history_data, current_subject
+        )
+        has_class_record = any(
+            lottery.get("class_name", "") for lottery in lotterys_data
+        )
+        format_weight, _, _ = format_weight_for_display(lotterys_data, "weight")
+
+        lotterys_data.sort(key=lambda x: x.get("draw_time", ""), reverse=True)
+
+        headers = ["Time", "ID", "Name"]
+        if has_class_record:
+            headers.append("Subject")
+        headers.append("Weight")
+
+        for lottery in lotterys_data:
+            row = [
+                lottery.get("draw_time", ""),
+                lottery.get("id", ""),
+                lottery.get("name", ""),
+            ]
+            if has_class_record:
+                class_name = lottery.get("class_name", "")
+                row.append(str(class_name) if class_name else "")
+            row.append(str(format_weight(lottery.get("weight", 0))))
+            rows.append(row)
+
+    else:
+        lotterys_data = get_lottery_prize_stats_data(
+            cleaned_lotterys, history_data, current_lottery_name, current_subject
+        )
+        has_class_record = any(
+            lottery.get("class_name", "") for lottery in lotterys_data
+        )
+        format_weight, _, _ = format_weight_for_display(lotterys_data, "weight")
+
+        lotterys_data.sort(key=lambda x: x.get("draw_time", ""), reverse=True)
+
+        headers = ["Time", "Count"]
+        if has_class_record:
+            headers.append("Subject")
+        headers.append("Weight")
+
+        for lottery in lotterys_data:
+            row = [
+                lottery.get("draw_time", ""),
+                str(lottery.get("draw_lottery_numbers", 0)),
+            ]
+            if has_class_record:
+                class_name = lottery.get("class_name", "")
+                row.append(str(class_name) if class_name else "")
+            row.append(str(format_weight(lottery.get("weight", ""))))
+            rows.append(row)
+
+    return headers, rows
+
+
+def _write_excel_stream(target_path, headers, rows):
+    import pandas as pd
+
+    for chunk_start in range(0, len(rows), 1000):
+        chunk = rows[chunk_start : chunk_start + 1000]
+        if chunk_start == 0:
+            df = pd.DataFrame(chunk, columns=headers)
+            df.to_excel(
+                str(target_path),
+                index=False,
+                engine="openpyxl",
+                startrow=0,
+            )
+        else:
+            from openpyxl import load_workbook
+
+            wb = load_workbook(str(target_path))
+            ws = wb.active
+            for row_data in chunk:
+                ws.append(row_data)
+            wb.save(str(target_path))
+
+
+def _write_csv_stream(target_path, headers, rows):
+    with open(str(target_path), "w", encoding="utf-8-sig", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(headers)
+        for row in rows:
+            writer.writerow(row)
+
+
+def _write_txt_stream(target_path, headers, rows, current_mode: int):
+    name_col_idx = _get_name_column_index(current_mode)
+    with open(str(target_path), "w", encoding="utf-8") as f:
+        if name_col_idx is not None:
+            for row in rows:
+                if name_col_idx < len(row):
+                    f.write(f"{row[name_col_idx]}\n")
+                else:
+                    f.write("\n")
+        else:
+            for row in rows:
+                f.write("\t".join(str(v) for v in row) + "\n")
+
+
 def export_history_table_data(
     table_widget,
     current_mode: int,
     i18n_domain: str,
     current_name: str,
     parent_widget=None,
+    current_subject: str = "",
+    current_item_name: str = "",
 ):
-    if table_widget.rowCount() == 0:
-        return
-
     file_path, selected_filter = QFileDialog.getSaveFileName(
         parent_widget,
         get_any_position_value_async(
@@ -60,41 +349,30 @@ def export_history_table_data(
         target_path = get_path(file_path)
         target_path.parent.mkdir(parents=True, exist_ok=True)
 
-        headers = []
-        for col in range(table_widget.columnCount()):
-            header_item = table_widget.horizontalHeaderItem(col)
-            headers.append(header_item.text() if header_item else f"列{col}")
+        if i18n_domain == "roll_call":
+            headers, rows = _build_roll_call_export_data(
+                current_name,
+                current_mode,
+                current_subject,
+                current_item_name,
+            )
+        else:
+            headers, rows = _build_lottery_export_data(
+                current_name,
+                current_mode,
+                current_subject,
+                current_item_name,
+            )
 
-        export_data = []
-        for row in range(table_widget.rowCount()):
-            row_data = {}
-            for col in range(table_widget.columnCount()):
-                item = table_widget.item(row, col)
-                row_data[headers[col]] = item.text() if item else ""
-            export_data.append(row_data)
+        if not rows:
+            return
 
         if export_type == "excel":
-            import pandas as pd
-
-            df = pd.DataFrame(export_data)
-            df.to_excel(str(target_path), index=False, engine="openpyxl")
+            _write_excel_stream(target_path, headers, rows)
         elif export_type == "csv":
-            import pandas as pd
-
-            df = pd.DataFrame(export_data)
-            df.to_csv(str(target_path), index=False, encoding="utf-8-sig")
+            _write_csv_stream(target_path, headers, rows)
         else:
-            name_col_idx = _get_name_column_index(current_mode)
-            with open(str(target_path), "w", encoding="utf-8") as f:
-                for row in range(table_widget.rowCount()):
-                    if name_col_idx is not None:
-                        item = table_widget.item(row, name_col_idx)
-                        f.write(f"{item.text()}\n" if item else "\n")
-                    else:
-                        for col in range(table_widget.columnCount()):
-                            item = table_widget.item(row, col)
-                            f.write(f"{item.text()}\t" if item else "\t")
-                        f.write("\n")
+            _write_txt_stream(target_path, headers, rows, current_mode)
 
         config = NotificationConfig(
             title=get_any_position_value_async(

--- a/app/view/settings/history/lottery_history_table.py
+++ b/app/view/settings/history/lottery_history_table.py
@@ -1025,9 +1025,9 @@ class lottery_history_table(GroupHeaderCardWidget):
 
         export_type = (
             "excel"
-            if "Excel 文件 (*.xlsx)" in selected_filter
+            if ".xlsx" in selected_filter
             else "csv"
-            if "CSV 文件 (*.csv)" in selected_filter
+            if ".csv" in selected_filter
             else "txt"
         )
 

--- a/app/view/settings/history/lottery_history_table.py
+++ b/app/view/settings/history/lottery_history_table.py
@@ -13,6 +13,7 @@ from qfluentwidgets import *
 from app.tools.variable import *
 from app.tools.path_utils import *
 from app.tools.personalised import *
+from app.tools.config import *
 from app.tools.settings_default import *
 from app.tools.settings_access import *
 from app.Language.obtain_language import *

--- a/app/view/settings/history/lottery_history_table.py
+++ b/app/view/settings/history/lottery_history_table.py
@@ -25,6 +25,7 @@ from app.common.history.history_reader import (
     get_lottery_session_data,
     get_lottery_prize_stats_data,
 )
+from .export_utils import export_history_table_data
 
 
 # ==================================================
@@ -994,134 +995,17 @@ class lottery_history_table(GroupHeaderCardWidget):
             self.available_subjects = []
 
     def export_history_data(self):
-        """导出当前表格数据到文件"""
         if not self.current_pool_name:
             return
 
-        if self.table.rowCount() == 0:
-            return
+        if self.current_row < self.total_rows:
+            self.force_load_all = True
+            self.refresh_data()
 
-        file_path, selected_filter = QFileDialog.getSaveFileName(
-            self,
-            get_any_position_value_async(
-                "qfiledialog",
-                "lottery",
-                "export_history",
-                "caption",
-                "name",
-            ),
-            f"{self.current_pool_name}_抽奖记录-SecRandom",
-            get_any_position_value_async(
-                "qfiledialog",
-                "lottery",
-                "export_history",
-                "filter",
-                "name",
-            ),
+        export_history_table_data(
+            table_widget=self.table,
+            current_mode=self.current_mode,
+            i18n_domain="lottery",
+            current_name=self.current_pool_name,
+            parent_widget=self,
         )
-
-        if not file_path:
-            return
-
-        export_type = (
-            "excel"
-            if ".xlsx" in selected_filter
-            else "csv"
-            if ".csv" in selected_filter
-            else "txt"
-        )
-
-        if export_type == "excel" and not file_path.endswith(".xlsx"):
-            file_path += ".xlsx"
-        elif export_type == "csv" and not file_path.endswith(".csv"):
-            file_path += ".csv"
-        elif export_type == "txt" and not file_path.endswith(".txt"):
-            file_path += ".txt"
-
-        try:
-            headers = []
-            for col in range(self.table.columnCount()):
-                header_item = self.table.horizontalHeaderItem(col)
-                headers.append(header_item.text() if header_item else f"列{col}")
-
-            export_data = []
-            for row in range(self.table.rowCount()):
-                row_data = {}
-                for col in range(self.table.columnCount()):
-                    item = self.table.item(row, col)
-                    row_data[headers[col]] = item.text() if item else ""
-                export_data.append(row_data)
-
-            if export_type == "excel":
-                import pandas as pd
-
-                df = pd.DataFrame(export_data)
-                df.to_excel(file_path, index=False, engine="openpyxl")
-            elif export_type == "csv":
-                import pandas as pd
-
-                df = pd.DataFrame(export_data)
-                df.to_csv(file_path, index=False, encoding="utf-8-sig")
-            else:
-                name_col_idx = None
-                for col in range(self.table.columnCount()):
-                    header_item = self.table.horizontalHeaderItem(col)
-                    if header_item and header_item.text() in ("名称", "Name"):
-                        name_col_idx = col
-                        break
-
-                with open(file_path, "w", encoding="utf-8") as f:
-                    for row in range(self.table.rowCount()):
-                        if name_col_idx is not None:
-                            item = self.table.item(row, name_col_idx)
-                            f.write(f"{item.text()}\n" if item else "\n")
-                        else:
-                            for col in range(self.table.columnCount()):
-                                item = self.table.item(row, col)
-                                f.write(f"{item.text()}\t" if item else "\t")
-                            f.write("\n")
-
-            config = NotificationConfig(
-                title=get_any_position_value_async(
-                    "notification",
-                    "lottery",
-                    "export",
-                    "title",
-                    "success",
-                    "name",
-                ),
-                content=(get_any_position_value_async(
-                    "notification",
-                    "lottery",
-                    "export",
-                    "content",
-                    "success",
-                    "name",
-                ) or "").format(path=file_path),
-                duration=3000,
-            )
-            show_notification(NotificationType.SUCCESS, config, parent=self)
-            logger.info(f"抽奖历史记录导出成功: {file_path}")
-
-        except Exception as e:
-            logger.exception(f"导出抽奖历史记录失败: {e}")
-            config = NotificationConfig(
-                title=get_any_position_value_async(
-                    "notification",
-                    "lottery",
-                    "export",
-                    "title",
-                    "failure",
-                    "name",
-                ),
-                content=(get_any_position_value_async(
-                    "notification",
-                    "lottery",
-                    "export",
-                    "content",
-                    "error",
-                    "name",
-                ) or "").format(message=str(e)),
-                duration=3000,
-            )
-            show_notification(NotificationType.ERROR, config, parent=self)

--- a/app/view/settings/history/lottery_history_table.py
+++ b/app/view/settings/history/lottery_history_table.py
@@ -1090,14 +1090,14 @@ class lottery_history_table(GroupHeaderCardWidget):
                     "success",
                     "name",
                 ),
-                content=get_any_position_value_async(
+                content=(get_any_position_value_async(
                     "notification",
                     "lottery",
                     "export",
                     "content",
                     "success",
                     "name",
-                ).format(path=file_path),
+                ) or "").format(path=file_path),
                 duration=3000,
             )
             show_notification(NotificationType.SUCCESS, config, parent=self)
@@ -1114,14 +1114,14 @@ class lottery_history_table(GroupHeaderCardWidget):
                     "failure",
                     "name",
                 ),
-                content=get_any_position_value_async(
+                content=(get_any_position_value_async(
                     "notification",
                     "lottery",
                     "export",
                     "content",
                     "error",
                     "name",
-                ).format(message=str(e)),
+                ) or "").format(message=str(e)),
                 duration=3000,
             )
             show_notification(NotificationType.ERROR, config, parent=self)

--- a/app/view/settings/history/lottery_history_table.py
+++ b/app/view/settings/history/lottery_history_table.py
@@ -998,9 +998,12 @@ class lottery_history_table(GroupHeaderCardWidget):
         if not self.current_pool_name:
             return
 
-        if self.current_row < self.total_rows:
-            self.force_load_all = True
-            self.refresh_data()
+        current_item_name = ""
+        if self.current_mode >= 2:
+            if hasattr(self, "mode_comboBox"):
+                current_item_name = self.mode_comboBox.currentText()
+            elif hasattr(self, "current_lottery_name"):
+                current_item_name = self.current_lottery_name
 
         export_history_table_data(
             table_widget=self.table,
@@ -1008,4 +1011,6 @@ class lottery_history_table(GroupHeaderCardWidget):
             i18n_domain="lottery",
             current_name=self.current_pool_name,
             parent_widget=self,
+            current_subject=self.current_subject,
+            current_item_name=current_item_name,
         )

--- a/app/view/settings/history/lottery_history_table.py
+++ b/app/view/settings/history/lottery_history_table.py
@@ -141,6 +141,20 @@ class lottery_history_table(GroupHeaderCardWidget):
             self.mode_subject_widget,
         )
 
+        # 创建导出按钮
+        self.export_button = PushButton(
+            get_content_name_async("lottery_history_table", "export_button")
+        )
+        self.export_button.setFixedWidth(120)
+        self.export_button.clicked.connect(self.export_history_data)
+
+        self.addGroup(
+            get_theme_icon("ic_fluent_document_arrow_down_20_filled"),
+            get_content_name_async("lottery_history_table", "export"),
+            get_content_description_async("lottery_history_table", "export"),
+            self.export_button,
+        )
+
     def create_table(self):
         """创建表格区域"""
         # 创建表格
@@ -977,3 +991,136 @@ class lottery_history_table(GroupHeaderCardWidget):
         except Exception as e:
             logger.exception(f"更新课程列表失败: {e}")
             self.available_subjects = []
+
+    def export_history_data(self):
+        """导出当前表格数据到文件"""
+        if not self.current_pool_name:
+            return
+
+        if self.table.rowCount() == 0:
+            return
+
+        file_path, selected_filter = QFileDialog.getSaveFileName(
+            self,
+            get_any_position_value_async(
+                "qfiledialog",
+                "lottery",
+                "export_history",
+                "caption",
+                "name",
+            ),
+            f"{self.current_pool_name}_抽奖记录-SecRandom",
+            get_any_position_value_async(
+                "qfiledialog",
+                "lottery",
+                "export_history",
+                "filter",
+                "name",
+            ),
+        )
+
+        if not file_path:
+            return
+
+        export_type = (
+            "excel"
+            if "Excel 文件 (*.xlsx)" in selected_filter
+            else "csv"
+            if "CSV 文件 (*.csv)" in selected_filter
+            else "txt"
+        )
+
+        if export_type == "excel" and not file_path.endswith(".xlsx"):
+            file_path += ".xlsx"
+        elif export_type == "csv" and not file_path.endswith(".csv"):
+            file_path += ".csv"
+        elif export_type == "txt" and not file_path.endswith(".txt"):
+            file_path += ".txt"
+
+        try:
+            headers = []
+            for col in range(self.table.columnCount()):
+                header_item = self.table.horizontalHeaderItem(col)
+                headers.append(header_item.text() if header_item else f"列{col}")
+
+            export_data = []
+            for row in range(self.table.rowCount()):
+                row_data = {}
+                for col in range(self.table.columnCount()):
+                    item = self.table.item(row, col)
+                    row_data[headers[col]] = item.text() if item else ""
+                export_data.append(row_data)
+
+            if export_type == "excel":
+                import pandas as pd
+
+                df = pd.DataFrame(export_data)
+                df.to_excel(file_path, index=False, engine="openpyxl")
+            elif export_type == "csv":
+                import pandas as pd
+
+                df = pd.DataFrame(export_data)
+                df.to_csv(file_path, index=False, encoding="utf-8-sig")
+            else:
+                name_col_idx = None
+                for col in range(self.table.columnCount()):
+                    header_item = self.table.horizontalHeaderItem(col)
+                    if header_item and header_item.text() in ("名称", "Name"):
+                        name_col_idx = col
+                        break
+
+                with open(file_path, "w", encoding="utf-8") as f:
+                    for row in range(self.table.rowCount()):
+                        if name_col_idx is not None:
+                            item = self.table.item(row, name_col_idx)
+                            f.write(f"{item.text()}\n" if item else "\n")
+                        else:
+                            for col in range(self.table.columnCount()):
+                                item = self.table.item(row, col)
+                                f.write(f"{item.text()}\t" if item else "\t")
+                            f.write("\n")
+
+            config = NotificationConfig(
+                title=get_any_position_value_async(
+                    "notification",
+                    "lottery",
+                    "export",
+                    "title",
+                    "success",
+                    "name",
+                ),
+                content=get_any_position_value_async(
+                    "notification",
+                    "lottery",
+                    "export",
+                    "content",
+                    "success",
+                    "name",
+                ).format(path=file_path),
+                duration=3000,
+            )
+            show_notification(NotificationType.SUCCESS, config, parent=self)
+            logger.info(f"抽奖历史记录导出成功: {file_path}")
+
+        except Exception as e:
+            logger.exception(f"导出抽奖历史记录失败: {e}")
+            config = NotificationConfig(
+                title=get_any_position_value_async(
+                    "notification",
+                    "lottery",
+                    "export",
+                    "title",
+                    "failure",
+                    "name",
+                ),
+                content=get_any_position_value_async(
+                    "notification",
+                    "lottery",
+                    "export",
+                    "content",
+                    "error",
+                    "name",
+                ).format(message=str(e)),
+                duration=3000,
+            )
+            show_notification(NotificationType.ERROR, config, parent=self)

--- a/app/view/settings/history/lottery_history_table.py
+++ b/app/view/settings/history/lottery_history_table.py
@@ -725,6 +725,22 @@ class lottery_history_table(GroupHeaderCardWidget):
         # 更新当前奖池名称
         self.current_pool_name = self.pool_comboBox.currentText()
 
+        # 更新模式下拉框中的奖品名称列表
+        if hasattr(self, "mode_comboBox"):
+            current_mode = self.mode_comboBox.currentIndex()
+            self.mode_comboBox.blockSignals(True)
+            self.mode_comboBox.clear()
+            self.all_names = get_all_names("lottery", self.current_pool_name)
+            self.mode_comboBox.addItems(
+                get_content_combo_name_async("lottery_history_table", "select_mode")
+                + self.all_names
+            )
+            if current_mode < self.mode_comboBox.count():
+                self.mode_comboBox.setCurrentIndex(current_mode)
+            else:
+                self.mode_comboBox.setCurrentIndex(0)
+            self.mode_comboBox.blockSignals(False)
+
         # 刷新表格数据
         self.refresh_data()
 

--- a/app/view/settings/history/roll_call_history_table.py
+++ b/app/view/settings/history/roll_call_history_table.py
@@ -1191,9 +1191,9 @@ class roll_call_history_table(GroupHeaderCardWidget):
 
         export_type = (
             "excel"
-            if "Excel 文件 (*.xlsx)" in selected_filter
+            if ".xlsx" in selected_filter
             else "csv"
-            if "CSV 文件 (*.csv)" in selected_filter
+            if ".csv" in selected_filter
             else "txt"
         )
 

--- a/app/view/settings/history/roll_call_history_table.py
+++ b/app/view/settings/history/roll_call_history_table.py
@@ -27,6 +27,7 @@ from app.common.history.history_reader import (
     get_roll_call_student_stats_data,
     check_class_has_gender_or_group,
 )
+from .export_utils import export_history_table_data
 
 
 # ==================================================
@@ -1160,134 +1161,17 @@ class roll_call_history_table(GroupHeaderCardWidget):
         self.table.setHorizontalHeaderLabels(headers)
 
     def export_history_data(self):
-        """导出当前表格数据到文件"""
         if not self.current_class_name:
             return
 
-        if self.table.rowCount() == 0:
-            return
+        if self.current_row < self.total_rows:
+            self.force_load_all = True
+            self.refresh_data()
 
-        file_path, selected_filter = QFileDialog.getSaveFileName(
-            self,
-            get_any_position_value_async(
-                "qfiledialog",
-                "roll_call",
-                "export_history",
-                "caption",
-                "name",
-            ),
-            f"{self.current_class_name}_点名记录-SecRandom",
-            get_any_position_value_async(
-                "qfiledialog",
-                "roll_call",
-                "export_history",
-                "filter",
-                "name",
-            ),
+        export_history_table_data(
+            table_widget=self.table,
+            current_mode=self.current_mode,
+            i18n_domain="roll_call",
+            current_name=self.current_class_name,
+            parent_widget=self,
         )
-
-        if not file_path:
-            return
-
-        export_type = (
-            "excel"
-            if ".xlsx" in selected_filter
-            else "csv"
-            if ".csv" in selected_filter
-            else "txt"
-        )
-
-        if export_type == "excel" and not file_path.endswith(".xlsx"):
-            file_path += ".xlsx"
-        elif export_type == "csv" and not file_path.endswith(".csv"):
-            file_path += ".csv"
-        elif export_type == "txt" and not file_path.endswith(".txt"):
-            file_path += ".txt"
-
-        try:
-            headers = []
-            for col in range(self.table.columnCount()):
-                header_item = self.table.horizontalHeaderItem(col)
-                headers.append(header_item.text() if header_item else f"列{col}")
-
-            export_data = []
-            for row in range(self.table.rowCount()):
-                row_data = {}
-                for col in range(self.table.columnCount()):
-                    item = self.table.item(row, col)
-                    row_data[headers[col]] = item.text() if item else ""
-                export_data.append(row_data)
-
-            if export_type == "excel":
-                import pandas as pd
-
-                df = pd.DataFrame(export_data)
-                df.to_excel(file_path, index=False, engine="openpyxl")
-            elif export_type == "csv":
-                import pandas as pd
-
-                df = pd.DataFrame(export_data)
-                df.to_csv(file_path, index=False, encoding="utf-8-sig")
-            else:
-                name_col_idx = None
-                for col in range(self.table.columnCount()):
-                    header_item = self.table.horizontalHeaderItem(col)
-                    if header_item and header_item.text() in ("姓名", "Name"):
-                        name_col_idx = col
-                        break
-
-                with open(file_path, "w", encoding="utf-8") as f:
-                    for row in range(self.table.rowCount()):
-                        if name_col_idx is not None:
-                            item = self.table.item(row, name_col_idx)
-                            f.write(f"{item.text()}\n" if item else "\n")
-                        else:
-                            for col in range(self.table.columnCount()):
-                                item = self.table.item(row, col)
-                                f.write(f"{item.text()}\t" if item else "\t")
-                            f.write("\n")
-
-            config = NotificationConfig(
-                title=get_any_position_value_async(
-                    "notification",
-                    "roll_call",
-                    "export",
-                    "title",
-                    "success",
-                    "name",
-                ),
-                content=(get_any_position_value_async(
-                    "notification",
-                    "roll_call",
-                    "export",
-                    "content",
-                    "success",
-                    "name",
-                ) or "").format(path=file_path),
-                duration=3000,
-            )
-            show_notification(NotificationType.SUCCESS, config, parent=self)
-            logger.info(f"点名历史记录导出成功: {file_path}")
-
-        except Exception as e:
-            logger.exception(f"导出点名历史记录失败: {e}")
-            config = NotificationConfig(
-                title=get_any_position_value_async(
-                    "notification",
-                    "roll_call",
-                    "export",
-                    "title",
-                    "failure",
-                    "name",
-                ),
-                content=(get_any_position_value_async(
-                    "notification",
-                    "roll_call",
-                    "export",
-                    "content",
-                    "error",
-                    "name",
-                ) or "").format(message=str(e)),
-                duration=3000,
-            )
-            show_notification(NotificationType.ERROR, config, parent=self)

--- a/app/view/settings/history/roll_call_history_table.py
+++ b/app/view/settings/history/roll_call_history_table.py
@@ -13,6 +13,7 @@ from qfluentwidgets import *
 from app.tools.variable import *
 from app.tools.path_utils import *
 from app.tools.personalised import *
+from app.tools.config import *
 from app.tools.settings_default import *
 from app.tools.settings_access import *
 from app.Language.obtain_language import *

--- a/app/view/settings/history/roll_call_history_table.py
+++ b/app/view/settings/history/roll_call_history_table.py
@@ -1164,9 +1164,12 @@ class roll_call_history_table(GroupHeaderCardWidget):
         if not self.current_class_name:
             return
 
-        if self.current_row < self.total_rows:
-            self.force_load_all = True
-            self.refresh_data()
+        current_item_name = ""
+        if self.current_mode >= 2:
+            if hasattr(self, "mode_comboBox"):
+                current_item_name = self.mode_comboBox.currentText()
+            elif hasattr(self, "current_student_name"):
+                current_item_name = self.current_student_name
 
         export_history_table_data(
             table_widget=self.table,
@@ -1174,4 +1177,6 @@ class roll_call_history_table(GroupHeaderCardWidget):
             i18n_domain="roll_call",
             current_name=self.current_class_name,
             parent_widget=self,
+            current_subject=self.current_subject,
+            current_item_name=current_item_name,
         )

--- a/app/view/settings/history/roll_call_history_table.py
+++ b/app/view/settings/history/roll_call_history_table.py
@@ -1256,14 +1256,14 @@ class roll_call_history_table(GroupHeaderCardWidget):
                     "success",
                     "name",
                 ),
-                content=get_any_position_value_async(
+                content=(get_any_position_value_async(
                     "notification",
                     "roll_call",
                     "export",
                     "content",
                     "success",
                     "name",
-                ).format(path=file_path),
+                ) or "").format(path=file_path),
                 duration=3000,
             )
             show_notification(NotificationType.SUCCESS, config, parent=self)
@@ -1280,14 +1280,14 @@ class roll_call_history_table(GroupHeaderCardWidget):
                     "failure",
                     "name",
                 ),
-                content=get_any_position_value_async(
+                content=(get_any_position_value_async(
                     "notification",
                     "roll_call",
                     "export",
                     "content",
                     "error",
                     "name",
-                ).format(message=str(e)),
+                ) or "").format(message=str(e)),
                 duration=3000,
             )
             show_notification(NotificationType.ERROR, config, parent=self)

--- a/app/view/settings/history/roll_call_history_table.py
+++ b/app/view/settings/history/roll_call_history_table.py
@@ -147,6 +147,20 @@ class roll_call_history_table(GroupHeaderCardWidget):
             self.mode_subject_widget,
         )
 
+        # 创建导出按钮
+        self.export_button = PushButton(
+            get_content_name_async("roll_call_history_table", "export_button")
+        )
+        self.export_button.setFixedWidth(120)
+        self.export_button.clicked.connect(self.export_history_data)
+
+        self.addGroup(
+            get_theme_icon("ic_fluent_document_arrow_down_20_filled"),
+            get_content_name_async("roll_call_history_table", "export"),
+            get_content_description_async("roll_call_history_table", "export"),
+            self.export_button,
+        )
+
     def create_table(self):
         """创建表格区域"""
         # 创建表格
@@ -1143,3 +1157,136 @@ class roll_call_history_table(GroupHeaderCardWidget):
 
         self.table.setColumnCount(len(headers))
         self.table.setHorizontalHeaderLabels(headers)
+
+    def export_history_data(self):
+        """导出当前表格数据到文件"""
+        if not self.current_class_name:
+            return
+
+        if self.table.rowCount() == 0:
+            return
+
+        file_path, selected_filter = QFileDialog.getSaveFileName(
+            self,
+            get_any_position_value_async(
+                "qfiledialog",
+                "roll_call",
+                "export_history",
+                "caption",
+                "name",
+            ),
+            f"{self.current_class_name}_点名记录-SecRandom",
+            get_any_position_value_async(
+                "qfiledialog",
+                "roll_call",
+                "export_history",
+                "filter",
+                "name",
+            ),
+        )
+
+        if not file_path:
+            return
+
+        export_type = (
+            "excel"
+            if "Excel 文件 (*.xlsx)" in selected_filter
+            else "csv"
+            if "CSV 文件 (*.csv)" in selected_filter
+            else "txt"
+        )
+
+        if export_type == "excel" and not file_path.endswith(".xlsx"):
+            file_path += ".xlsx"
+        elif export_type == "csv" and not file_path.endswith(".csv"):
+            file_path += ".csv"
+        elif export_type == "txt" and not file_path.endswith(".txt"):
+            file_path += ".txt"
+
+        try:
+            headers = []
+            for col in range(self.table.columnCount()):
+                header_item = self.table.horizontalHeaderItem(col)
+                headers.append(header_item.text() if header_item else f"列{col}")
+
+            export_data = []
+            for row in range(self.table.rowCount()):
+                row_data = {}
+                for col in range(self.table.columnCount()):
+                    item = self.table.item(row, col)
+                    row_data[headers[col]] = item.text() if item else ""
+                export_data.append(row_data)
+
+            if export_type == "excel":
+                import pandas as pd
+
+                df = pd.DataFrame(export_data)
+                df.to_excel(file_path, index=False, engine="openpyxl")
+            elif export_type == "csv":
+                import pandas as pd
+
+                df = pd.DataFrame(export_data)
+                df.to_csv(file_path, index=False, encoding="utf-8-sig")
+            else:
+                name_col_idx = None
+                for col in range(self.table.columnCount()):
+                    header_item = self.table.horizontalHeaderItem(col)
+                    if header_item and header_item.text() in ("姓名", "Name"):
+                        name_col_idx = col
+                        break
+
+                with open(file_path, "w", encoding="utf-8") as f:
+                    for row in range(self.table.rowCount()):
+                        if name_col_idx is not None:
+                            item = self.table.item(row, name_col_idx)
+                            f.write(f"{item.text()}\n" if item else "\n")
+                        else:
+                            for col in range(self.table.columnCount()):
+                                item = self.table.item(row, col)
+                                f.write(f"{item.text()}\t" if item else "\t")
+                            f.write("\n")
+
+            config = NotificationConfig(
+                title=get_any_position_value_async(
+                    "notification",
+                    "roll_call",
+                    "export",
+                    "title",
+                    "success",
+                    "name",
+                ),
+                content=get_any_position_value_async(
+                    "notification",
+                    "roll_call",
+                    "export",
+                    "content",
+                    "success",
+                    "name",
+                ).format(path=file_path),
+                duration=3000,
+            )
+            show_notification(NotificationType.SUCCESS, config, parent=self)
+            logger.info(f"点名历史记录导出成功: {file_path}")
+
+        except Exception as e:
+            logger.exception(f"导出点名历史记录失败: {e}")
+            config = NotificationConfig(
+                title=get_any_position_value_async(
+                    "notification",
+                    "roll_call",
+                    "export",
+                    "title",
+                    "failure",
+                    "name",
+                ),
+                content=get_any_position_value_async(
+                    "notification",
+                    "roll_call",
+                    "export",
+                    "content",
+                    "error",
+                    "name",
+                ).format(message=str(e)),
+                duration=3000,
+            )
+            show_notification(NotificationType.ERROR, config, parent=self)

--- a/app/view/settings/history/roll_call_history_table.py
+++ b/app/view/settings/history/roll_call_history_table.py
@@ -858,6 +858,22 @@ class roll_call_history_table(GroupHeaderCardWidget):
         # 更新当前班级名称
         self.current_class_name = self.class_comboBox.currentText()
 
+        # 更新模式下拉框中的学生名称列表
+        if hasattr(self, "mode_comboBox"):
+            current_mode = self.mode_comboBox.currentIndex()
+            self.mode_comboBox.blockSignals(True)
+            self.mode_comboBox.clear()
+            self.all_names = get_all_names("roll_call", self.current_class_name)
+            self.mode_comboBox.addItems(
+                get_content_combo_name_async("roll_call_history_table", "select_mode")
+                + self.all_names
+            )
+            if current_mode < self.mode_comboBox.count():
+                self.mode_comboBox.setCurrentIndex(current_mode)
+            else:
+                self.mode_comboBox.setCurrentIndex(0)
+            self.mode_comboBox.blockSignals(False)
+
         # 更新课程列表
         self._update_subject_list()
 

--- a/app/view/settings/list_management/lottery_table.py
+++ b/app/view/settings/list_management/lottery_table.py
@@ -35,8 +35,16 @@ class lottery_table(GroupHeaderCardWidget):
         self.parent = parent
         self.setTitle(get_content_name_async("lottery_table", "title"))
         self.setBorderRadius(8)
+        self._search_timer = QTimer(self)
+        self._search_timer.setSingleShot(True)
+        self._search_timer.setInterval(300)
+        self._search_timer.timeout.connect(self._apply_search_filter)
+
         # 创建抽奖名单选择区域
         QTimer.singleShot(APPLY_DELAY, self.create_lottery_selection)
+
+        # 创建搜索栏
+        QTimer.singleShot(APPLY_DELAY, self.create_search_bar)
 
         # 创建表格区域
         QTimer.singleShot(APPLY_DELAY, self.create_table)
@@ -85,6 +93,46 @@ class lottery_table(GroupHeaderCardWidget):
             get_content_description_async("lottery_table", "select_pool_name"),
             self.lottery_comboBox,
         )
+
+    def create_search_bar(self):
+        """创建搜索栏"""
+        self.search_line_edit = SearchLineEdit()
+        self.search_line_edit.setPlaceholderText(
+            get_content_name_async("lottery_table", "search_placeholder")
+        )
+        self.search_line_edit.setClearButtonEnabled(True)
+        self.search_line_edit.textChanged.connect(self._on_search_text_changed)
+
+        self.addGroup(
+            get_theme_icon("ic_fluent_search_20_filled"),
+            get_content_name_async("lottery_table", "search"),
+            get_content_description_async("lottery_table", "search"),
+            self.search_line_edit,
+        )
+
+    def _on_search_text_changed(self):
+        """搜索文本变化时启动防抖计时器"""
+        self._search_timer.start()
+
+    def _apply_search_filter(self):
+        """根据搜索关键词过滤表格行"""
+        if not hasattr(self, "table") or self.table is None:
+            return
+
+        keyword = self.search_line_edit.text().strip().lower()
+
+        for row in range(self.table.rowCount()):
+            if not keyword:
+                self.table.setRowHidden(row, False)
+                continue
+
+            matched = False
+            for col in range(self.table.columnCount()):
+                item = self.table.item(row, col)
+                if item and keyword in item.text().lower():
+                    matched = True
+                    break
+            self.table.setRowHidden(row, not matched)
 
     def create_table(self):
         """创建表格区域"""
@@ -283,6 +331,7 @@ class lottery_table(GroupHeaderCardWidget):
         finally:
             # 恢复信号
             self.table.blockSignals(False)
+            self._apply_search_filter()
 
     def save_table_data(self, row, col):
         """保存表格编辑的数据"""

--- a/app/view/settings/list_management/lottery_table.py
+++ b/app/view/settings/list_management/lottery_table.py
@@ -118,6 +118,8 @@ class lottery_table(GroupHeaderCardWidget):
         """根据搜索关键词过滤表格行"""
         if not hasattr(self, "table") or self.table is None:
             return
+        if not hasattr(self, "search_line_edit"):
+            return
 
         keyword = self.search_line_edit.text().strip().lower()
 

--- a/app/view/settings/list_management/roll_call_table.py
+++ b/app/view/settings/list_management/roll_call_table.py
@@ -35,8 +35,16 @@ class roll_call_table(GroupHeaderCardWidget):
         self.parent = parent
         self.setTitle(get_content_name_async("roll_call_table", "title"))
         self.setBorderRadius(8)
+        self._search_timer = QTimer(self)
+        self._search_timer.setSingleShot(True)
+        self._search_timer.setInterval(300)
+        self._search_timer.timeout.connect(self._apply_search_filter)
+
         # 创建班级选择区域
         QTimer.singleShot(APPLY_DELAY, self.create_class_selection)
+
+        # 创建搜索栏
+        QTimer.singleShot(APPLY_DELAY, self.create_search_bar)
 
         # 创建表格区域
         QTimer.singleShot(APPLY_DELAY, self.create_table)
@@ -79,6 +87,46 @@ class roll_call_table(GroupHeaderCardWidget):
             get_content_description_async("roll_call_table", "select_class_name"),
             self.class_comboBox,
         )
+
+    def create_search_bar(self):
+        """创建搜索栏"""
+        self.search_line_edit = SearchLineEdit()
+        self.search_line_edit.setPlaceholderText(
+            get_content_name_async("roll_call_table", "search_placeholder")
+        )
+        self.search_line_edit.setClearButtonEnabled(True)
+        self.search_line_edit.textChanged.connect(self._on_search_text_changed)
+
+        self.addGroup(
+            get_theme_icon("ic_fluent_search_20_filled"),
+            get_content_name_async("roll_call_table", "search"),
+            get_content_description_async("roll_call_table", "search"),
+            self.search_line_edit,
+        )
+
+    def _on_search_text_changed(self):
+        """搜索文本变化时启动防抖计时器"""
+        self._search_timer.start()
+
+    def _apply_search_filter(self):
+        """根据搜索关键词过滤表格行"""
+        if not hasattr(self, "table") or self.table is None:
+            return
+
+        keyword = self.search_line_edit.text().strip().lower()
+
+        for row in range(self.table.rowCount()):
+            if not keyword:
+                self.table.setRowHidden(row, False)
+                continue
+
+            matched = False
+            for col in range(self.table.columnCount()):
+                item = self.table.item(row, col)
+                if item and keyword in item.text().lower():
+                    matched = True
+                    break
+            self.table.setRowHidden(row, not matched)
 
     def create_table(self):
         """创建表格区域"""
@@ -272,6 +320,7 @@ class roll_call_table(GroupHeaderCardWidget):
         finally:
             # 恢复信号
             self.table.blockSignals(False)
+            self._apply_search_filter()
 
     def save_table_data(self, row, col):
         """保存表格编辑的数据"""

--- a/app/view/settings/list_management/roll_call_table.py
+++ b/app/view/settings/list_management/roll_call_table.py
@@ -112,6 +112,8 @@ class roll_call_table(GroupHeaderCardWidget):
         """根据搜索关键词过滤表格行"""
         if not hasattr(self, "table") or self.table is None:
             return
+        if not hasattr(self, "search_line_edit"):
+            return
 
         keyword = self.search_line_edit.text().strip().lower()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = "==3.13.5"
 
 dependencies = [
     # === UI / 界面 ===
-    "PySide6-Fluent-Widgets==1.11.0",
+    "PySide6-Fluent-Widgets==1.11.2",
     "pyside6>6.6.3.1",
     "pysidesix-frameless-window>=0.7.4",
     "darkdetect==0.8.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3602,30 +3602,30 @@ wheels = [
 
 [[package]]
 name = "pyside6-fluent-widgets"
-version = "1.11.0"
+version = "1.11.2"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
 dependencies = [
     { name = "darkdetect" },
     { name = "pyside6" },
     { name = "pysidesix-frameless-window" },
 ]
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/f7/79/89ede298a98552317b71c199f7001f728401ea5e5f05ccece5cb390f71f6/pyside6_fluent_widgets-1.11.0.tar.gz", hash = "sha256:ac74b7d08fd78b06304416ac6d62cc47818949d79605899eb64c53bd99c6c322" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/f1/22/01a72ab00873fac2575e8045cd4dfcb003afc0f0764982c706817be5629a/pyside6_fluent_widgets-1.11.2.tar.gz", hash = "sha256:cf49ff76b9b2ad1dc24f071a1b2a3f5f0a67d7adf655915071ddfb7342caf175" }
 wheels = [
-    { url = "https://mirrors.aliyun.com/pypi/packages/3e/4a/49d2b3b7bb35e006de4a3a2192c78a005cd1d44bd18e33ae12fc6cb3672c/pyside6_fluent_widgets-1.11.0-py3-none-any.whl", hash = "sha256:d13763304137fb843b955dbaad9e0ffafca306018769d0ea9094b9f707ff7938" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/78/cb/ad62113621b3e619e4fa069a383e5060a6169e93a9df73f15f2cf68bdf5a/pyside6_fluent_widgets-1.11.2-py3-none-any.whl", hash = "sha256:7d3bb3d79b743cbb16eef0a0471f1d0c47d6c8c8dd78402820bd3cdae4da1ea0" },
 ]
 
 [[package]]
 name = "pysidesix-frameless-window"
-version = "0.7.7"
+version = "0.8.1"
 source = { registry = "https://mirrors.aliyun.com/pypi/simple" }
 dependencies = [
     { name = "pycocoa", marker = "sys_platform == 'darwin'" },
     { name = "pyobjc", marker = "sys_platform == 'darwin'" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://mirrors.aliyun.com/pypi/packages/cf/ba/c41e25e8884224d15b14ffad34c921f350a6b0cfce823f150a514a0d3788/pysidesix_frameless_window-0.7.7.tar.gz", hash = "sha256:4f975bae89a6ebd8babeed693341f242b268c94816e81602e026eb95703d4eb4" }
+sdist = { url = "https://mirrors.aliyun.com/pypi/packages/e7/44/ee4b9ead46ec5fcc4d9a303f6ac82cb17b0e188bfe629ef962c4046cded5/pysidesix_frameless_window-0.8.1.tar.gz", hash = "sha256:95eefa64abdaca9d730bc097fd39e2cd07d3443a47a1645cc936a0076996d7cd" }
 wheels = [
-    { url = "https://mirrors.aliyun.com/pypi/packages/70/e2/fb1e36cbd8ed5c0db161ace24ad40b5278ac9af6fecc9bcd6ab68712fb1c/pysidesix_frameless_window-0.7.7-py3-none-any.whl", hash = "sha256:cd6b2961cc30d9290f84462bc59de674bea6a72df5d36fb57d5fb49d660c13e8" },
+    { url = "https://mirrors.aliyun.com/pypi/packages/60/02/13dc76880e9f54102b8d4859a1a14061c6914c12d8c8554dc49ef55ab209/pysidesix_frameless_window-0.8.1-py3-none-any.whl", hash = "sha256:0445e7ce095c3631893ec54edb470a47c2bb05ea64db736f446211550b7c2237" },
 ]
 
 [[package]]
@@ -3888,7 +3888,7 @@ requires-dist = [
     { name = "pypng", specifier = "~=0.20220715.0" },
     { name = "pyqrcode", specifier = "~=1.2.1" },
     { name = "pyside6", specifier = ">6.6.3.1" },
-    { name = "pyside6-fluent-widgets", specifier = "==1.11.0" },
+    { name = "pyside6-fluent-widgets", specifier = "==1.11.2" },
     { name = "pysidesix-frameless-window", specifier = ">=0.7.4" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "pythonnet", specifier = ">=3.0.5" },


### PR DESCRIPTION
## 概述

实现 #232 请求的功能：在查看名单时添加搜索/筛选功能。

## 变更内容

### 新增功能
- **点名表格搜索栏**：在点名表格卡片中添加搜索栏，支持按学号、姓名、性别、小组、标签进行关键词筛选
- **抽奖表格搜索栏**：在抽奖表格卡片中添加搜索栏，支持按序号、奖品、权重、标签、数量进行关键词筛选

### 技术实现
- 使用 `SearchLineEdit` 组件（qfluentwidgets），与项目现有搜索组件风格一致
- 搜索输入带 300ms 防抖处理，避免频繁刷新
- 搜索匹配所有列的文本内容（不区分大小写）
- 清空搜索框自动恢复显示所有行
- 数据刷新后自动重新应用搜索过滤
- 使用 `ic_fluent_search_20_filled` 图标，与 Fluent Design 风格一致

### 国际化
- 添加中文、英文、日文三语翻译
- 搜索栏标题和占位符文本均支持多语言

## 修改文件
- `app/view/settings/list_management/roll_call_table.py` — 点名表格添加搜索功能
- `app/view/settings/list_management/lottery_table.py` — 抽奖表格添加搜索功能
- `app/Language/modules/list_management.py` — 添加搜索相关翻译

## 截图

搜索栏位于班级/奖池选择器下方、表格上方，输入关键词即可实时筛选。

Closes #232