### PR TITLE
修正错误的冷启动权重调整

### DIFF
--- a/app/common/history/weight_utils.py
+++ b/app/common/history/weight_utils.py
@@ -178,7 +178,7 @@ def _calculate_frequency_factor(settings, total_count, max_total_count, is_cold_
         factor = math.sqrt(max_total_count + 1) / math.sqrt(total_count + 1)
 
     if is_cold_start:
-        factor = min(0.8 + (factor * 0.2), factor)
+        factor = max(0.8 + (factor * 0.2), factor)
 
     return factor * settings["frequency_weight"]
 


### PR DESCRIPTION
app/common/history/weight_utils.py:161-183
def _calculate_frequency_factor(settings, total_count, max_total_count, is_cold_start):
  ……
      if is_cold_start:
        factor = min(0.8 + (factor * 0.2), factor) 

只有当原factor>1.0时min才会选择新值。
原代码factor修正并不会更改factor的值

改为max则意味着在冷启动模式下这个抽取会更倾向于随机而不是频率惩罚