### PR TITLE
fix: 修复重启时单实例检查顺序，确保重启时可以完全退出

### DIFF
--- a/app/view/main/window.py
+++ b/app/view/main/window.py
@@ -1220,10 +1220,11 @@ class MainWindow(FluentWindow):
         执行安全验证后重启程序，清理所有资源"""
         logger.info("正在发起重启请求...")
 
-        if self.pre_class_reset_timer.isActive():
-            self.pre_class_reset_timer.stop()
-
-        self.cleanup_shortcuts()
+        self._stop_pre_class_reset_timer()
+        self._cleanup_shortcuts()
+        self._stop_ipc_client()
+        self._close_all_windows()
+        self._close_main_window()
 
         # 使用 EXIT_CODE_RESTART 退出码来触发重启
         # main.py 中的 handle_exit() 函数会检测此退出码并执行重启逻辑

--- a/main.py
+++ b/main.py
@@ -186,9 +186,9 @@ def initialize_application():
 
     wm.app_start_time = time.perf_counter()
 
-    shared_memory, is_first_instance = check_single_instance()
-
     time.sleep(PROCESS_EXIT_WAIT_SECONDS)
+
+    shared_memory, is_first_instance = check_single_instance()
 
     return program_dir, shared_memory, is_first_instance
 


### PR DESCRIPTION
fix #198   这个问题似乎需要连接到ClassIsland且机器性能较低才能复现
对重启部分进行了以下修改：
确保重启前按顺序停止定时器、清理快捷键、停止 IPC、关闭所有窗口、关闭主窗口，这应该能解决#198
先等待旧进程退出资源放后，再进行单实例检查