### PR TITLE
Revert gender filtering change

### DIFF
--- a/SecRandom/Services/SecAgent/SecAgentHttpHostedService.cs
+++ b/SecRandom/Services/SecAgent/SecAgentHttpHostedService.cs
@@ -188,17 +188,16 @@ public sealed class SecAgentHttpHostedService(
 
         var requestedCount = Math.Clamp(arguments["count"]?.GetValue<int>() ?? 1, 1, 100);
         if (mode == "flash") requestedCount = 1;
-        var gender = StringArgument(arguments, "gender");
         var includeTags = StringArray(arguments, "include_tags");
         var excludeTags = StringArray(arguments, "exclude_tags");
         var includeIds = StringArray(arguments, "include_ids");
         var includeNames = StringArray(arguments, "include_names");
         var listName = profileService.CurrentStudentList?.Name ?? string.Empty;
-        var temporaryCounts = temporaryRecordService.GetStudentCounts(listName, gender, string.Empty);
+        var temporaryCounts = temporaryRecordService.GetStudentCounts(listName, string.Empty, string.Empty);
 
         var result = await InvokeAuthorizedAsync(SecurityOperation.QuickDrawStart, () =>
         {
-            var draw = drawEngine.DrawStudent(requestedCount, student => Matches(student, gender, includeTags, excludeTags, includeIds, includeNames)
+            var draw = drawEngine.DrawStudent(requestedCount, student => Matches(student, includeTags, excludeTags, includeIds, includeNames)
                 && !HasReachedTemporaryLimit(student, temporaryCounts), DrawSettingsType.QuickDraw, linkageDrawCoordinator.GetCourseName());
             if (!draw.IsSuccess || draw.Result.Count == 0)
                 return Task.FromResult(draw);
@@ -206,7 +205,7 @@ public sealed class SecAgentHttpHostedService(
             profileService.RecordStudentHistory(draw.Result, DateTime.Now, requestedCount,
                 drawMethod: (int)configHandler.Data.QuickDrawSettings.DrawType,
                 courseName: linkageDrawCoordinator.GetCourseName());
-            temporaryRecordService.RecordStudents(listName, gender, string.Empty, draw.Result);
+            temporaryRecordService.RecordStudents(listName, string.Empty, string.Empty, draw.Result);
             if (mode == "flash")
                 notificationService.QueueStudents(NotificationSettingsType.QuickDraw, linkageDrawCoordinator.GetCourseName(), draw.Result);
             return Task.FromResult(draw);
@@ -243,12 +242,11 @@ public sealed class SecAgentHttpHostedService(
         return threshold > 0 && temporaryCounts.GetValueOrDefault(ProfileRecordIdentity.EnsureRecordId(student)) >= threshold;
     }
 
-    private static bool Matches(Student student, string gender, IReadOnlyCollection<string> includeTags, IReadOnlyCollection<string> excludeTags,
+    private static bool Matches(Student student, IReadOnlyCollection<string> includeTags, IReadOnlyCollection<string> excludeTags,
         IReadOnlyCollection<string> includeIds, IReadOnlyCollection<string> includeNames)
     {
         var tags = student.Tags.Split([',', ';', ' '], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        return (string.IsNullOrWhiteSpace(gender) || string.Equals(student.Gender, gender, StringComparison.OrdinalIgnoreCase))
-            && includeTags.All(tag => tags.Contains(tag, StringComparer.OrdinalIgnoreCase))
+        return includeTags.All(tag => tags.Contains(tag, StringComparer.OrdinalIgnoreCase))
             && excludeTags.All(tag => !tags.Contains(tag, StringComparer.OrdinalIgnoreCase))
             && (includeIds.Count == 0 || includeIds.Contains(student.Id, StringComparer.OrdinalIgnoreCase))
             && (includeNames.Count == 0 || includeNames.Contains(student.Name, StringComparer.OrdinalIgnoreCase));


### PR DESCRIPTION
This PR reverts #263 and restores the SecRandom master branch behavior before the gender-filtering change. It is intentionally left for repository maintainers to review and merge.