### PR TITLE
fix: load plugin market key from desktop assets

### DIFF
--- a/SecRandom/Services/Plugins/PluginMarketService.cs
+++ b/SecRandom/Services/Plugins/PluginMarketService.cs
@@ -1,5 +1,6 @@
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.IO;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -236,9 +237,24 @@ public sealed class PluginMarketService(
 
     private static byte[] ReadEmbeddedPublicKey()
     {
+        // Desktop builds keep the SecRandom assets beside the executable instead of
+        // embedding them in the shared application assembly.
+        var externalPath = Path.Combine(
+            AppContext.BaseDirectory,
+            "Assets",
+            "Plugins",
+            "plugin-market-public-key.txt");
+        if (File.Exists(externalPath))
+            return ParsePublicKey(File.ReadAllText(externalPath));
+
         using var stream = AssetLoader.Open(new Uri("avares://SecRandom/Assets/Plugins/plugin-market-public-key.txt"));
         using var reader = new StreamReader(stream, Encoding.UTF8);
-        var key = Convert.FromBase64String(reader.ReadToEnd().Trim());
+        return ParsePublicKey(reader.ReadToEnd());
+    }
+
+    private static byte[] ParsePublicKey(string text)
+    {
+        var key = Convert.FromBase64String(text.Trim());
         if (key.Length != Ed25519PublicKeyParameters.KeySize || key.All(static value => value == 0))
             throw new CryptographicException(SR.M_PublicKeyInvalid);
         return key;


### PR DESCRIPTION
## Summary

- Load `Assets/Plugins/plugin-market-public-key.txt` from the desktop output directory when desktop assets are not embedded in `SecRandom.dll`.
- Keep the existing `avares://` lookup for bundled mobile/non-desktop builds.

## Root cause

Desktop builds set `SecRandomBundleAssetsInAssembly=false`, so the market public key is copied beside the executable rather than embedded as an Avalonia resource. `PluginMarketService` only tried `avares://...`, causing index signature verification to fail and leaving the market list empty.

The official market index already contains `secrandom.secagent`; this fixes the desktop client loading it.

## Validation

- `git diff --check` passed.
- The separate worktree NuGet restore was attempted but timed out while contacting external package sources.